### PR TITLE
Update package name and don't specify build-system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "wagtail-channels"
+name = "wagtail-websockets"
 version = "0.1.0"
 description = ""
 authors = ["Michael Hearn <git@mikehearn.net>"]
@@ -13,6 +13,3 @@ channels_redis = "^2.3"
 
 [tool.poetry.dev-dependencies]
 python-language-server = {version = "^0.22.0",extras = ["all"]}
-[build-system]
-requires = ["poetry>=0.12", "setuptools", "wheel"]
-build-backend = "poetry.masonry.api"


### PR DESCRIPTION
Fixes #1 

I removed the build-system section of `pyproject.toml` because users don't need to use poetry when the package gets installed through pip.