### PR TITLE
Prevent unauthenticated users from connecting to WebSocket

### DIFF
--- a/content_locking/consumers.py
+++ b/content_locking/consumers.py
@@ -20,7 +20,7 @@ class PresenceConsumer(AsyncWebsocketConsumer):
         self.username = None
 
     def user_can_connect(self):
-        return self.scope['user'].is_authenticated and self.scope['user'].has_perm('wagtail.access_admin') and False
+        return self.scope['user'].is_authenticated and self.scope['user'].has_perm('wagtail.access_admin')
 
     async def connect(self):
         """


### PR DESCRIPTION
This adds checks to to make sure that the connecting user is both authenticated and has permission to access the Wagtail admin.